### PR TITLE
Add $WORKSPACE_NAME, $RESOURCE_GROUP

### DIFF
--- a/Labs/06/setup.sh
+++ b/Labs/06/setup.sh
@@ -37,5 +37,5 @@ az ml compute create --name ${COMPUTE_CLUSTER} --size STANDARD_DS11_V2 --max-ins
 
 # Create data assets
 echo "Create training data asset:"
-az ml data create --type mltable --name "diabetes-training" --path ./diabetes-data -w mlw-dp100-labs -g rg-dp100-labs
-az ml data create --type mltable --name "oj-training" --path ./orange-juice-data -w mlw-dp100-labs -g rg-dp100-labs
+az ml data create --type mltable --name "diabetes-training" --path ./diabetes-data -w $WORKSPACE_NAME -g $RESOURCE_GROUP
+az ml data create --type mltable --name "oj-training" --path ./orange-juice-data -w $WORKSPACE_NAME -g $RESOURCE_GROUP


### PR DESCRIPTION
# Module: 00
## Lab/Demo: 06

Errors:
The names were hardcoded in the data asset section of the script, which caused errors and missing data in the data source.

```bash
Create training data asset:
(ResourceGroupNotFound) Resource group 'rg-dp100-labs' could not be found.
Code: ResourceGroupNotFound
Message: Resource group 'rg-dp100-labs' could not be found.
(ResourceGroupNotFound) Resource group 'rg-dp100-labs' could not be found.
Code: ResourceGroupNotFound
Message: Resource group 'rg-dp100-labs' could not be found.
```

```bash
(ParentResourceNotFound) Can not perform.requested operation on nested resource. Parent resource 'mlw-dp100-labs' not found.
Code: ParentResourceNotFound
Message: Can not perform.requested operation on nested resource. Parent resource 'mlw-dp100-labs' not found.

```

Changes proposed in this pull request:

- Change `mlw-dp100-labs` to `$WORKSPACE_NAME`
- Change `rg-dp100-labs` to `$RESOURCE_GROUP`
-