### PR TITLE
Small changes to labs 2 &4, bigger changes to lab 5

### DIFF
--- a/Instructions/02-Explore-Azure-Machine-Learning.md
+++ b/Instructions/02-Explore-Azure-Machine-Learning.md
@@ -27,27 +27,27 @@ In this exercise, you'll use the Azure portal to provision Azure Machine Learnin
     - **Key vault**: *Note the default new key vault that will be created for your workspace*
     - **Application insights**: *Note the default new application insights resource that will be created for your workspace*
     - **Container registry**: None (*one will be created automatically the first time you deploy a model to a container*)
-3. Wait for the workspace and its associated resources to be created - this typically takes around 5 minutes. 
+3. Wait for the workspace and its associated resources to be created - this typically takes around 5 minutes.
 
 > **Note**: When you create an Azure Machine Learning workspace, you can use some advanced options to restrict access through a *private endpoint* and specify custom keys for data encryption. We won't use these options in this exercise - but you should be aware of them!
 
 ## Explore the Azure Machine Learning studio
 
-*Azure Machine Learning studio* is a web-based portal through which you can access the Azure Machine Learning workspace. You can use the Azure Machine Learning studio to manage all assets and resources within your workspace. 
+*Azure Machine Learning studio* is a web-based portal through which you can access the Azure Machine Learning workspace. You can use the Azure Machine Learning studio to manage all assets and resources within your workspace.
 
 1. Go to the resource group named **rg-dp100-labs**.
-1. Confirm that the resource group contains your Azure Machine Learning workspace, an Application Insights, a Key Vault, and a Storage Account. 
+1. Confirm that the resource group contains your Azure Machine Learning workspace, an Application Insights, a Key Vault, and a Storage Account.
 1. Select your Azure Machine Learning workspace.
 1. Select **Launch studio** from the **Overview** page. Another tab will open in your browser to open the Azure Machine Learning studio.
-1. Close any pop-ups that appear in the studio. 
-1. Note the different pages shown on the left side of the studio. If only the symbols are visible in the menu, select the &#9776; icon to expand the menu and explore the names of the pages. 
+1. Close any pop-ups that appear in the studio.
+1. Note the different pages shown on the left side of the studio. If only the symbols are visible in the menu, select the &#9776; icon to expand the menu and explore the names of the pages.
 1. Note the **Author** section, which includes **Notebooks**, **Automated ML**, and the **Designer**. These are the three ways you can create your own machine learning models within the Azure Machine Learning studio.
 1. Note the **Assets** section, which includes **Data**, **Jobs**, and **Models** among other things. Assets are either consumed or created when training or scoring a model. Assets are used to train, deploy, and manage your models and can be versioned to keep track of your history.
-1. Note the **Manage** section, which includes **Compute** among other things. These are infrastructural resources needed to train or deploy a machine learning model. 
+1. Note the **Manage** section, which includes **Compute** among other things. These are infrastructural resources needed to train or deploy a machine learning model.
 
 ## Author a training pipeline
 
-To explore the use of the assets and resources in the Azure Machine Learning workspace, let's try and train a model. 
+To explore the use of the assets and resources in the Azure Machine Learning workspace, let's try and train a model.
 
 A quick way to author a model training pipeline is by using the **Designer**.
 
@@ -55,10 +55,10 @@ A quick way to author a model training pipeline is by using the **Designer**.
 > Pop-ups may appear throughout to guide you through the studio. You can close and ignore all pop-ups and focus on the instructions of this lab.
 
 1. Select the **Designer** page from the menu on the left side of the studio.
-1. Select the **Regression - Automobile Price Prediction (Basic)** sample. 
-    
+1. Select the **Regression - Automobile Price Prediction (Basic)** sample.
+
     A new pipeline appears. At the top of the pipeline, a component is shown to load **Automobile price data (raw)**. The pipeline processes the data and trains a linear regression model to predict the price for each automobile.
-1. Select **Submit** at the top of the page. An error appears as you have not select a compute target yet. The pipeline can't run without compute resources. 
+1. Select **Submit** at the top of the page. An error appears as you have not select a compute target yet. The pipeline can't run without compute resources.
 
 Let's create a compute target.
 
@@ -72,9 +72,9 @@ To run any workload within the Azure Machine Learning workspace, you'll need a c
     - **Kubernetes clusters**: A Kubernetes cluster used for training and scoring. Ideal for real-time model deployment at a large scale.
     - **Attached compute**: Attach your existing Azure compute resources to the workspace, such as Virtual Machines or Azure Databricks clusters.
 
-To train a machine learning model that you authored with the Designer, you can use either a compute instance or compute cluster.
+    To train a machine learning model that you authored with the Designer, you can use either a compute instance or compute cluster.
 
-2. On the **Compute instances** tab, add a new compute instance with the following settings. 
+2. On the **Compute instances** tab, add a new compute instance with the following settings.
     - **Compute name**: *enter a unique name*
     - **Location**: *Automatically the same location as your workspace*
     - **Virtual machine type**: `CPU`
@@ -120,8 +120,8 @@ Any time you run a script or pipeline in the Azure Machine Learning workspace, i
 1. To view the pipeline job details, select the **Job overview** at the top right to expand the **Pipeline job overview**. 
 1. Note that in the **Overview** parameters, you can find the job's status, who created the pipeline, when it was created and how long it took to run the complete pipeline (among other things).
 
-    When you run a script or pipeline as a job, you can define any inputs and document any outputs. Azure Machine Learning also automatically keeps track of your job's properties. By using jobs, you can easily view your history to understand what you or your colleagues have already done. 
-    
+    When you run a script or pipeline as a job, you can define any inputs and document any outputs. Azure Machine Learning also automatically keeps track of your job's properties. By using jobs, you can easily view your history to understand what you or your colleagues have already done.
+
     During experimentation, jobs help keep track of the different models you train to compare and identify the best model. During production, jobs allow you to check whether automated workloads ran as expected.
 
 1. When your job is completed, you can also view the details of each individual component run, including the output. Feel free to explore the pipeline to understand how the model is trained.
@@ -133,5 +133,5 @@ When you finish exploring Azure Machine Learning, you should delete the resource
 1. Close the Azure Machine Learning studio tab and return to the Azure portal.
 1. In the Azure portal, on the **Home** page, select **Resource groups**.
 1. Select the **rg-dp100-labs** resource group.
-1. At the top of the **Overview** page for your resource group, select **Delete resource group**. 
+1. At the top of the **Overview** page for your resource group, select **Delete resource group**.
 1. Enter the resource group name to confirm you want to delete it, and select **Delete**.

--- a/Instructions/02-Explore-developer-tools.md
+++ b/Instructions/02-Explore-developer-tools.md
@@ -89,6 +89,7 @@ Though a compute instance is ideal for development, a compute cluster is better 
 To create a compute cluster, you can use the Azure CLI, similar to creating a compute instance. 
 
 You'll create a compute cluster with the following settings:
+
 - **Compute name**: aml-cluster
 - **Virtual machine size**: STANDARD_DS11_V2
 - **Compute type**: AmlCompute *(Creates a compute cluster)*
@@ -102,7 +103,7 @@ You'll create a compute cluster with the following settings:
     az ml compute create --name "aml-cluster" --size STANDARD_DS11_V2 --max-instances 2 --type AmlCompute -w mlw-dp100-labs -g rg-dp100-labs
     ```
 
-## Configure your work station with the Azure Machine Learning studio
+## Configure your workstation with the Azure Machine Learning studio
 
 Though the Azure CLI is ideal for automation, you may want to review the output of the commands you executed. You can use the Azure Machine Learning Studio to check whether resources and assets have been created, and to check whether jobs ran successfully or review why a job failed. 
 
@@ -129,15 +130,15 @@ Now that you've verified that the necessary compute has been created, you can us
 
     ```
     git clone https://github.com/MicrosoftLearning/mslearn-azure-ml.git azure-ml-labs
-    ``` 
+    ```
 
 1. When the command has completed, in the **Files** pane, select **&#8635;** to refresh the view and verify that a new **Users/*your-user-name*/azure-ml-labs** folder has been created. 
 1. Open the **Labs/02/Run training script.ipynb** notebook.
     
-    > Select **Authenticate** and follow the necessary steps if a notification appears asking you to authenticate. 
+    > Select **Authenticate** and follow the necessary steps if a notification appears asking you to authenticate.
 
 1. Verify that the notebook uses the **Python 3.8 - AzureML** kernel. Each kernel has its own image with its own set of packages pre-installed.
-1. Run all cells in the notebook. 
+1. Run all cells in the notebook.
 
 A new job will be created in the Azure Machine Learning workspace. The job tracks the inputs defined in the job configuration, the code used, and the outputs like metrics to evaluate the model.
 
@@ -147,7 +148,7 @@ When you submit a job to the Azure Machine Learning workspace, you can review it
 
 1. Either select the job URL provided as output in the notebook, or navigate to the **Jobs** page in the Azure Machine Learning studio.
 1. A new experiment is listed named **diabetes-training**. Select the latest job **diabetes-pythonv2-train**.
-1. Review the job's **Properties**. Note the job **Status**: 
+1. Review the job's **Properties**. Note the job **Status**:
     - **Queued**: The job is waiting for compute to become available.
     - **Preparing**: The compute cluster is resizing or the environment is being installed on the compute target.
     - **Running**: The training script is being executed. 

--- a/Instructions/02-Explore-developer-tools.md
+++ b/Instructions/02-Explore-developer-tools.md
@@ -12,6 +12,7 @@ You can use various tools to interact with the Azure Machine Learning workspace.
 You'll need an [Azure subscription](https://azure.microsoft.com/free?azure-portal=true) in which you have administrative-level access.
 
 The commonly used developer tools for interacting with the Azure Machine Learning workspace are:
+
 - **Azure CLI** with the Azure Machine Learning extension: This command-line approach is ideal for the automation of infrastructure.
 - **Azure Machine Learning studio**: Use the user-friendly UI to explore the workspace and all of its capabilities.
 - **Python SDK** for Azure Machine Learning: Use to submit jobs and manage models from a Jupyter notebook, ideal for data scientists.
@@ -20,13 +21,13 @@ You'll explore each of these tools for tasks that are commonly done with that to
 
 ## Provision the infrastructure with the Azure CLI
 
-For a data scientist to train a machine learning model with Azure Machine Learning, you'll need to set up the necessary infrastructure. You can use the Azure CLI with the Azure Machine Learning extension to create an Azure Machine Learning workspace and resources like a compute instance. 
+For a data scientist to train a machine learning model with Azure Machine Learning, you'll need to set up the necessary infrastructure. You can use the Azure CLI with the Azure Machine Learning extension to create an Azure Machine Learning workspace and resources like a compute instance.
 
 To start, open the Azure Cloud Shell, install the Azure Machine Learning extension and clone the Git repo.
 
 1. In a browser, open the Azure portal at `https://portal.azure.com/`, signing in with your Microsoft account.
 1. Select the \[>_] (*Cloud Shell*) button at the top of the page to the right of the search box. This opens a Cloud Shell pane at the bottom of the portal.
-1. Select **Bash** if asked. The first time you open the cloud shell, you will be asked to choose the type of shell you want to use (*Bash* or *PowerShell*). 
+1. Select **Bash** if asked. The first time you open the cloud shell, you will be asked to choose the type of shell you want to use (*Bash* or *PowerShell*).
 1. Check that the correct subscription is specified and select **Create storage** if you are asked to create storage for your cloud shell. Wait for the storage to be created.
 1. Remove any ML CLI extensions (both version 1 and 2) to avoid any conflicts with previous versions with this command:
     
@@ -35,9 +36,9 @@ To start, open the Azure Cloud Shell, install the Azure Machine Learning extensi
     az extension remove -n ml
     ```
 
-    > Use `SHIFT + INSERT` to paste your copied code into the Cloud Shell. 
+    > Use `SHIFT + INSERT` to paste your copied code into the Cloud Shell.
 
-    > Ignore any (error) messages that say that the extensions were not installed. 
+    > Ignore any (error) messages that say that the extensions were not installed.
 
 1. Install the Azure Machine Learning (v2) extension with the following command:
     
@@ -57,24 +58,25 @@ To start, open the Azure Cloud Shell, install the Azure Machine Learning extensi
     az ml workspace create --name "mlw-dp100-labs" -g "rg-dp100-labs"
     ```
 
-1. Wait for the workspace and its associated resources to be created - this typically takes around 5 minutes. 
+1. Wait for the workspace and its associated resources to be created - this typically takes around 5 minutes.
 
 ## Create a compute instance with the Azure CLI
 
-Another important part of the infrastructure needed to train a machine learning model is **compute**. Though you can train models locally, it's more scalable and cost efficient to use cloud compute. 
+Another important part of the infrastructure needed to train a machine learning model is **compute**. Though you can train models locally, it's more scalable and cost efficient to use cloud compute.
 
-When data scientists are developing a machine learning model in the Azure Machine Learning workspace, they want to use a virtual machine on which they can run Jupyter notebooks. For development, a **compute instance** is an ideal fit. 
+When data scientists are developing a machine learning model in the Azure Machine Learning workspace, they want to use a virtual machine on which they can run Jupyter notebooks. For development, a **compute instance** is an ideal fit.
 
-After creating an Azure Machine Learning workspace, you can also create a compute instance using the Azure CLI. 
+After creating an Azure Machine Learning workspace, you can also create a compute instance using the Azure CLI.
 
 In this exercise, you'll create a compute instance with the following settings:
+
 - **Compute name**: *Name of compute instance. Has to be unique and fewer than 24 characters.*
 - **Virtual machine size**: STANDARD_DS11_V2
 - **Compute type** (instance or cluster): ComputeInstance
 - **Azure Machine Learning workspace name**: mlw-dp100-labs
 - **Resource group**: rg-dp100-labs
 
-1. Use the following command to create a compute instance in your workspace. If the compute instance name contains "XXXX", replace it with random numbers to create a unique name. 
+1. Use the following command to create a compute instance in your workspace. If the compute instance name contains "XXXX", replace it with random numbers to create a unique name.
 
     ```azurecli
     az ml compute create --name "ciXXXX" --size STANDARD_DS11_V2 --type ComputeInstance -w mlw-dp100-labs -g rg-dp100-labs
@@ -86,7 +88,7 @@ In this exercise, you'll create a compute instance with the following settings:
 
 Though a compute instance is ideal for development, a compute cluster is better suited when we want to train machine learning models. Only when a job is submitted to use the compute cluster, will it resize to more than 0 nodes and run the job. Once the compute cluster is no longer needed, it will automatically resize back to 0 nodes to minimize costs. 
 
-To create a compute cluster, you can use the Azure CLI, similar to creating a compute instance. 
+To create a compute cluster, you can use the Azure CLI, similar to creating a compute instance.
 
 You'll create a compute cluster with the following settings:
 
@@ -105,11 +107,11 @@ You'll create a compute cluster with the following settings:
 
 ## Configure your workstation with the Azure Machine Learning studio
 
-Though the Azure CLI is ideal for automation, you may want to review the output of the commands you executed. You can use the Azure Machine Learning Studio to check whether resources and assets have been created, and to check whether jobs ran successfully or review why a job failed. 
+Though the Azure CLI is ideal for automation, you may want to review the output of the commands you executed. You can use the Azure Machine Learning Studio to check whether resources and assets have been created, and to check whether jobs ran successfully or review why a job failed.
 
 1. In the Azure portal, navigate to the Azure Machine Learning workspace named **mlw-dp100-labs**.
 1. Select the Azure Machine Learning workspace, and in its **Overview** page, select **Launch studio**. Another tab will open in your browser to open the Azure Machine Learning studio.
-1. Close any pop-ups that appear in the studio. 
+1. Close any pop-ups that appear in the studio.
 1. Within the Azure Machine Learning studio, navigate to the **Compute** page and verify that the compute instance and cluster you created in the previous section exist. The compute instance should be running, the cluster should be idle and have 0 nodes running.
 
 ## Use the Python SDK to train a model
@@ -132,9 +134,9 @@ Now that you've verified that the necessary compute has been created, you can us
     git clone https://github.com/MicrosoftLearning/mslearn-azure-ml.git azure-ml-labs
     ```
 
-1. When the command has completed, in the **Files** pane, select **&#8635;** to refresh the view and verify that a new **Users/*your-user-name*/azure-ml-labs** folder has been created. 
+1. When the command has completed, in the **Files** pane, select **&#8635;** to refresh the view and verify that a new **Users/*your-user-name*/azure-ml-labs** folder has been created.
 1. Open the **Labs/02/Run training script.ipynb** notebook.
-    
+
     > Select **Authenticate** and follow the necessary steps if a notification appears asking you to authenticate.
 
 1. Verify that the notebook uses the **Python 3.8 - AzureML** kernel. Each kernel has its own image with its own set of packages pre-installed.
@@ -151,7 +153,7 @@ When you submit a job to the Azure Machine Learning workspace, you can review it
 1. Review the job's **Properties**. Note the job **Status**:
     - **Queued**: The job is waiting for compute to become available.
     - **Preparing**: The compute cluster is resizing or the environment is being installed on the compute target.
-    - **Running**: The training script is being executed. 
+    - **Running**: The training script is being executed.
     - **Finalizing**: The training script ran and the job is being updated with all final information.
     - **Completed**: The job successfully completed and is terminated.
     - **Failed**: The job failed and is terminated.
@@ -165,5 +167,5 @@ When you finish exploring Azure Machine Learning, you should delete the resource
 1. Close the Azure Machine Learning studio tab and return to the Azure portal.
 1. In the Azure portal, on the **Home** page, select **Resource groups**.
 1. Select the **rg-dp100-labs** resource group.
-1. At the top of the **Overview** page for your resource group, select **Delete resource group**. 
+1. At the top of the **Overview** page for your resource group, select **Delete resource group**.
 1. Enter the resource group name to confirm you want to delete it, and select **Delete**.

--- a/Instructions/03-Make-data-available.md
+++ b/Instructions/03-Make-data-available.md
@@ -15,16 +15,17 @@ You'll need an [Azure subscription](https://azure.microsoft.com/free?azure-porta
 
 ## Provision an Azure Machine Learning workspace
 
-An Azure Machine Learning *workspace* provides a central place for managing all resources and assets you need to train and manage your models. You can interact with the Azure Machine Learning workspace through the studio, Python SDK, and Azure CLI. 
+An Azure Machine Learning *workspace* provides a central place for managing all resources and assets you need to train and manage your models. You can interact with the Azure Machine Learning workspace through the studio, Python SDK, and Azure CLI.
 
 You'll use a Shell script which uses the Azure CLI to provision the workspace and necessary resources. Next, you'll use the Designer in the Azure Machine Learning studio to train and compare models.
 
 ### Create the workspace and compute resources
 
 To create the Azure Machine Learning workspace and compute resources, you'll use the Azure CLI. All necessary commands are grouped in a Shell script for you to execute.
+
 1. In a browser, open the Azure portal at `https://portal.azure.com/`, signing in with your Microsoft account.
 1. Select the \[>_] (*Cloud Shell*) button at the top of the page to the right of the search box. This opens a Cloud Shell pane at the bottom of the portal.
-1. Select **Bash** if asked. The first time you open the cloud shell, you will be asked to choose the type of shell you want to use (*Bash* or *PowerShell*). 
+1. Select **Bash** if asked. The first time you open the cloud shell, you will be asked to choose the type of shell you want to use (*Bash* or *PowerShell*).
 1. Check that the correct subscription is specified and select **Create storage** if you are asked to create storage for your cloud shell. Wait for the storage to be created.
 1. Enter the following commands in the terminal to clone this repo:
 
@@ -33,7 +34,7 @@ To create the Azure Machine Learning workspace and compute resources, you'll use
     git clone https://github.com/MicrosoftLearning/mslearn-azure-ml.git azure-ml-labs
     ```
 
-    > Use `SHIFT + INSERT` to paste your copied code into the Cloud Shell. 
+    > Use `SHIFT + INSERT` to paste your copied code into the Cloud Shell.
 
 1. Enter the following commands after the repo has been cloned, to change to the folder for this lab and run the **setup.sh** script it contains:
 
@@ -42,20 +43,20 @@ To create the Azure Machine Learning workspace and compute resources, you'll use
     ./setup.sh
     ```
 
-    > Ignore any (error) messages that say that the extensions were not installed. 
+    > Ignore any (error) messages that say that the extensions were not installed.
 
-1. Wait for the script to complete - this typically takes around 5-10 minutes. 
+1. Wait for the script to complete - this typically takes around 5-10 minutes.
 
 ## Explore the default datastores
 
 When you create an Azure Machine Learning workspace, a Storage Account is automatically created and connected to your workspace. You'll explore how the Storage Account is connected.
 
-1. In the Azure portal, navigate to the new resource group named **rg-dp100-labs**.
+1. In the Azure portal, navigate to the new resource group named **rg-dp100-xxxx**.
 1. Select the Storage Account in the resource group. The name often starts with the name you provided for the workspace (without hyphens).
 1. Review the **Overview** page of the Storage Account. Note that the Storage Account has several options for **Data storage** as shown in the Overview pane, and in the left menu.
 1. Select **Containers** to explore the Blob storage part of the Storage Account. 
-1. Note the **azureml-blobstore-...** container. The default datastore for data assets uses this container to store data. 
-1. Using the &#43; **Container** button at the top of the screen, create a new container and name it `training-data`. 
+1. Note the **azureml-blobstore-...** container. The default datastore for data assets uses this container to store data.
+1. Using the &#43; **Container** button at the top of the screen, create a new container and name it `training-data`.
 1. Select **File shares** from the left menu to explore the File share part of the Storage Account.
 1. Note the **code-...** file share. Any notebooks in the workspace are stored here. After cloning the lab materials, you can find the files in this file share, in the **code-.../Users/*your-user-name*/azure-ml-labs** folder.
 
@@ -66,8 +67,8 @@ To create a datastore in the Azure Machine Learning workspace, you need to provi
 1. In the Storage Account, select the **Access keys** tab from the left menu.
 1. Note that two keys are provided: key1 and key2. Each key has the same functionality. 
 1. Select **Show** for the **Key** field under **key1**.
-1. Copy the value of the **Key** field to a notepad. You'll need to paste this value into the notebook later. 
-1. Copy the name of your storage account from the top of the page. The name should start with **mlwdp100storage...** You'll need to paste this value into the notebook later too. 
+1. Copy the value of the **Key** field to a notepad. You'll need to paste this value into the notebook later.
+1. Copy the name of your storage account from the top of the page. The name should start with **mlwdp100storage...** You'll need to paste this value into the notebook later too.
 
 > **Note**:
 > Copy the account key and name to a notepad to avoid automatic capitalization (which happens in Word). The key is case-sensitive.
@@ -82,7 +83,7 @@ To create a datastore and data assets with the Python SDK, you'll need to clone 
 1. Within the Azure Machine Learning studio, navigate to the **Compute** page and verify that the compute instance and cluster you created in the previous section exist. The compute instance should be running, the cluster should be idle and have 0 nodes running.
 1. In the **Compute instances** tab, find your compute instance, and select the **Terminal** application.
 1. In the terminal, install the Python SDK on the compute instance by running the following commands in the terminal:
-    
+
     ```
     pip uninstall azure-ai-ml
     pip install azure-ai-ml
@@ -92,12 +93,12 @@ To create a datastore and data assets with the Python SDK, you'll need to clone 
     > Ignore any (error) messages that say that the packages were not installed.
 
 1. Run the following command to clone a Git repository containing notebooks, data, and other files to your workspace:
-    
+
     ```
     git clone https://github.com/MicrosoftLearning/mslearn-azure-ml.git azure-ml-labs
     ```
  
-1. When the command has completed, in the **Files** pane, click **&#8635;** to refresh the view and verify that a new **Users/*your-user-name*/azure-ml-labs** folder has been created. 
+1. When the command has completed, in the **Files** pane, click **&#8635;** to refresh the view and verify that a new **Users/*your-user-name*/azure-ml-labs** folder has been created.
 
 **Optionally**, in another browser tab, navigate back to the [Azure portal](https://portal.azure.com?azure-portal=true). Explore the file share **code-...** in the Storage account again to find the cloned lab materials in the newly created **azure-ml-labs** folder.
 
@@ -107,9 +108,9 @@ The code to create a datastore and data assets with the Python SDK is provided i
 
 1. Open the **Labs/03/Work with data.ipynb** notebook.
 
-    > Select **Authenticate** and follow the necessary steps if a notification appears asking you to authenticate. 
+    > Select **Authenticate** and follow the necessary steps if a notification appears asking you to authenticate.
 
-1. Verify that the notebook uses the **Python 3.8 - AzureML** kernel. 
+1. Verify that the notebook uses the **Python 3.8 - AzureML** kernel.
 1. Run all cells in the notebook.
 
 ## Optional: Explore the data assets
@@ -127,6 +128,6 @@ When you finish exploring Azure Machine Learning, you should delete the resource
 
 1. Close the Azure Machine Learning studio tab and return to the Azure portal.
 1. In the Azure portal, on the **Home** page, select **Resource groups**.
-1. Select the **rg-dp100-labs** resource group.
-1. At the top of the **Overview** page for your resource group, select **Delete resource group**. 
+1. Select the **rg-dp100-xxxx** resource group.
+1. At the top of the **Overview** page for your resource group, select **Delete resource group**.
 1. Enter the resource group name to confirm you want to delete it, and select **Delete**.

--- a/Instructions/03-Make-data-available.md
+++ b/Instructions/03-Make-data-available.md
@@ -51,7 +51,7 @@ To create the Azure Machine Learning workspace and compute resources, you'll use
 
 When you create an Azure Machine Learning workspace, a Storage Account is automatically created and connected to your workspace. You'll explore how the Storage Account is connected.
 
-1. In the Azure portal, navigate to the new resource group named **rg-dp100-xxxx**.
+1. In the Azure portal, navigate to the new resource group named **rg-dp100-...**.
 1. Select the Storage Account in the resource group. The name often starts with the name you provided for the workspace (without hyphens).
 1. Review the **Overview** page of the Storage Account. Note that the Storage Account has several options for **Data storage** as shown in the Overview pane, and in the left menu.
 1. Select **Containers** to explore the Blob storage part of the Storage Account. 
@@ -128,6 +128,6 @@ When you finish exploring Azure Machine Learning, you should delete the resource
 
 1. Close the Azure Machine Learning studio tab and return to the Azure portal.
 1. In the Azure portal, on the **Home** page, select **Resource groups**.
-1. Select the **rg-dp100-xxxx** resource group.
+1. Select the **rg-dp100-...** resource group.
 1. At the top of the **Overview** page for your resource group, select **Delete resource group**.
 1. Enter the resource group name to confirm you want to delete it, and select **Delete**.

--- a/Instructions/04-Work-with-compute.md
+++ b/Instructions/04-Work-with-compute.md
@@ -21,7 +21,7 @@ To create the Azure Machine Learning workspace, you'll use the Azure CLI. All ne
 
 1. In a browser, open the Azure portal at `https://portal.azure.com/`, signing in with your Microsoft account.
 1. Select the \[>_] (*Cloud Shell*) button at the top of the page to the right of the search box. This opens a Cloud Shell pane at the bottom of the portal.
-1. Select **Bash** if asked. The first time you open the cloud shell, you will be asked to choose the type of shell you want to use (*Bash* or *PowerShell*). 
+1. Select **Bash** if asked. The first time you open the cloud shell, you will be asked to choose the type of shell you want to use (*Bash* or *PowerShell*).
 1. Check that the correct subscription is specified and select **Create storage** if you are asked to create storage for your cloud shell. Wait for the storage to be created.
 1. To avoid any conflicts with previous versions, remove any ML CLI extensions (both version 1 and 2) by running this command in the terminal:
 
@@ -30,9 +30,9 @@ To create the Azure Machine Learning workspace, you'll use the Azure CLI. All ne
     az extension remove -n ml
     ```
 
-    > Use `SHIFT + INSERT` to paste your copied code into the Cloud Shell. 
+    > Use `SHIFT + INSERT` to paste your copied code into the Cloud Shell.
 
-    > Ignore any (error) messages that say that the extensions were not installed. 
+    > Ignore any (error) messages that say that the extensions were not installed.
 
 1. Install the Azure Machine Learning (v2) extension with the following command:
     
@@ -52,7 +52,7 @@ To create the Azure Machine Learning workspace, you'll use the Azure CLI. All ne
     az ml workspace create --name "mlw-dp100-labs" -g "rg-dp100-labs"
     ```
 
-1. Wait for the command to complete - this typically takes around 5-10 minutes. 
+1. Wait for the command to complete - this typically takes around 5-10 minutes.
 
 ## Create the compute setup script
 
@@ -62,7 +62,7 @@ To run notebooks within the Azure Machine Learning workspace, you'll need a comp
 1. Select the Azure Machine Learning workspace, and in its **Overview** page, select **Launch studio**. Another tab will open in your browser to open the Azure Machine Learning studio.
 1. Close any pop-ups that appear in the studio.
 1. Within the Azure Machine Learning studio, navigate to the **Notebooks** page.
-1. In the **Files** pane, select the &#10753; icon to **Add files**. 
+1. In the **Files** pane, select the &#10753; icon to **Add files**.
 1. Select **Create new file**.
 1. Verify that the file location is **Users/*your-user-name***.
 1. Change the file type to **Bash (*.sh)**.
@@ -89,15 +89,15 @@ To create the compute instance, you can use the studio, Python SDK, or Azure CLI
     - **Virtual machine type**: *CPU*
     - **Virtual machine size**: *Standard_DS11_v2*
 1. Select **Next: Advanced settings**.
-1. Select **Add schedule** and configure the schedule to **stop** the compute instance every day at **18:00** or **6:00 PM**. 
-1. Select the toggle for **Provision with setup script**. 
+1. Select **Add schedule** and configure the schedule to **stop** the compute instance every day at **18:00** or **6:00 PM**.
+1. Select the toggle for **Provision with setup script**.
 1. Select the **compute-setup.sh** script you created previously.
 1. Review the other advanced settings but do **not** select them:
     - **Enable SSH access**: *You can use this to enable direct access to the virtual machine using an SSH client.*
     - **Enable virtual network**: *You would typically use this in an enterprise environment to enhance network security.*
     - **Assign to another user**: *You can use this to assign a compute instance to another data scientist.*
 1. **Create** the compute instance and wait for it to start and its state to change to **Running**.
-1. When the compute instance is running, navigate to the **Notebooks** page. In the **Files** pane, click **&#8635;** to refresh the view and verify that a new **Users/*your-user-name*/dp100-azure-ml-labs** folder has been created. 
+1. When the compute instance is running, navigate to the **Notebooks** page. In the **Files** pane, click **&#8635;** to refresh the view and verify that a new **Users/*your-user-name*/dp100-azure-ml-labs** folder has been created.
 
 ## Configure the compute instance
 
@@ -113,7 +113,7 @@ When you've created the the compute instance, you can run notebooks on it. You m
 
     > Ignore any (error) messages that say that the packages were not installed.
 
-1. When the packages are installed, you can close the tab to terminate the terminal. 
+1. When the packages are installed, you can close the tab to terminate the terminal.
 
 ## Create a compute cluster
 
@@ -121,9 +121,9 @@ Notebooks are ideal for development or iterative work during experimentation. Wh
 
 1. Open the **Labs/04/Work with compute.ipynb** notebook.
 
-    > Select **Authenticate** and follow the necessary steps if a notification appears asking you to authenticate. 
+    > Select **Authenticate** and follow the necessary steps if a notification appears asking you to authenticate.
 
-1. Verify that the notebook uses the **Python 3.8 - AzureML** kernel. 
+1. Verify that the notebook uses the **Python 3.8 - AzureML** kernel.
 1. Run all cells in the notebook.
 
 ## Delete Azure resources
@@ -133,5 +133,5 @@ When you finish exploring Azure Machine Learning, you should delete the resource
 1. Close the Azure Machine Learning studio tab and return to the Azure portal.
 1. In the Azure portal, on the **Home** page, select **Resource groups**.
 1. Select the **rg-dp100-labs** resource group.
-1. At the top of the **Overview** page for your resource group, select **Delete resource group**. 
+1. At the top of the **Overview** page for your resource group, select **Delete resource group**.
 1. Enter the resource group name to confirm you want to delete it, and select **Delete**.

--- a/Instructions/04-Work-with-environments.md
+++ b/Instructions/04-Work-with-environments.md
@@ -15,7 +15,7 @@ You'll need an [Azure subscription](https://azure.microsoft.com/free?azure-porta
 
 ## Provision an Azure Machine Learning workspace
 
-An Azure Machine Learning *workspace* provides a central place for managing all resources and assets you need to train and manage your models. You can interact with the Azure Machine Learning workspace through the studio, Python SDK, and Azure CLI. 
+An Azure Machine Learning *workspace* provides a central place for managing all resources and assets you need to train and manage your models. You can interact with the Azure Machine Learning workspace through the studio, Python SDK, and Azure CLI.
 
 You'll use the Azure CLI to provision the workspace and necessary compute, and you'll use the Python SDK to train a classification model with Automated Machine Learning.
 
@@ -25,7 +25,7 @@ To create the Azure Machine Learning workspace and compute resources, you'll use
 
 1. In a browser, open the Azure portal at `https://portal.azure.com/`, signing in with your Microsoft account.
 1. Select the \[>_] (*Cloud Shell*) button at the top of the page to the right of the search box. This opens a Cloud Shell pane at the bottom of the portal.
-1. Select **Bash** if asked. The first time you open the cloud shell, you will be asked to choose the type of shell you want to use (*Bash* or *PowerShell*). 
+1. Select **Bash** if asked. The first time you open the cloud shell, you will be asked to choose the type of shell you want to use (*Bash* or *PowerShell*).
 1. Check that the correct subscription is specified and select **Create storage** if you are asked to create storage for your cloud shell. Wait for the storage to be created.
 1. In the terminal, enter the following commands to clone this repo:
 
@@ -34,7 +34,7 @@ To create the Azure Machine Learning workspace and compute resources, you'll use
     git clone https://github.com/MicrosoftLearning/mslearn-azure-ml.git azure-ml-labs
     ```
 
-    > Use `SHIFT + INSERT` to paste your copied code into the Cloud Shell. 
+    > Use `SHIFT + INSERT` to paste your copied code into the Cloud Shell.
 
 1. After the repo has been cloned, enter the following commands to change to the folder for this lab and run the **setup.sh** script it contains:
 
@@ -43,9 +43,9 @@ To create the Azure Machine Learning workspace and compute resources, you'll use
     ./setup.sh
     ```
 
-    > Ignore any (error) messages that say that the extensions were not installed. 
+    > Ignore any (error) messages that say that the extensions were not installed.
 
-1. Wait for the script to complete - this typically takes around 5-10 minutes. 
+1. Wait for the script to complete - this typically takes around 5-10 minutes.
 
 ## Clone the lab materials
 
@@ -90,6 +90,6 @@ When you finish exploring Azure Machine Learning, you should delete the resource
 
 1. Close the Azure Machine Learning studio tab and return to the Azure portal.
 1. In the Azure portal, on the **Home** page, select **Resource groups**.
-1. Select the **rg-dp100-labs** resource group.
+1. Select the **rg-dp100-xxxx** resource group.
 1. At the top of the **Overview** page for your resource group, select **Delete resource group**.
 1. Enter the resource group name to confirm you want to delete it, and select **Delete**.

--- a/Instructions/04-Work-with-environments.md
+++ b/Instructions/04-Work-with-environments.md
@@ -51,7 +51,7 @@ To create the Azure Machine Learning workspace and compute resources, you'll use
 
 When you've created the workspace and necessary compute resources, you can open the Azure Machine Learning studio and clone the lab materials. 
 
-1. In the Azure portal, navigate to the Azure Machine Learning workspace named **mlw-dp100-xxxx******.
+1. In the Azure portal, navigate to the Azure Machine Learning workspace named **mlw-dp100-xxxx**.
 1. Select the Azure Machine Learning workspace, and in its **Overview** page, select **Launch studio**. Another tab will open in your browser to open the Azure Machine Learning studio.
 1. Close any pop-ups that appear in the studio.
 1. Within the Azure Machine Learning studio, navigate to the **Compute** page and verify that the compute instance and cluster you created in the previous section exist. The compute instance should be running, the cluster should be idle and have 0 nodes running.

--- a/Instructions/04-Work-with-environments.md
+++ b/Instructions/04-Work-with-environments.md
@@ -51,7 +51,7 @@ To create the Azure Machine Learning workspace and compute resources, you'll use
 
 When you've created the workspace and necessary compute resources, you can open the Azure Machine Learning studio and clone the lab materials. 
 
-1. In the Azure portal, navigate to the Azure Machine Learning workspace named **mlw-dp100-xxxx**.
+1. In the Azure portal, navigate to the Azure Machine Learning workspace named **mlw-dp100-...**.
 1. Select the Azure Machine Learning workspace, and in its **Overview** page, select **Launch studio**. Another tab will open in your browser to open the Azure Machine Learning studio.
 1. Close any pop-ups that appear in the studio.
 1. Within the Azure Machine Learning studio, navigate to the **Compute** page and verify that the compute instance and cluster you created in the previous section exist. The compute instance should be running, the cluster should be idle and have 0 nodes running.
@@ -90,6 +90,6 @@ When you finish exploring Azure Machine Learning, you should delete the resource
 
 1. Close the Azure Machine Learning studio tab and return to the Azure portal.
 1. In the Azure portal, on the **Home** page, select **Resource groups**.
-1. Select the **rg-dp100-xxxx** resource group.
+1. Select the **rg-dp100-...** resource group.
 1. At the top of the **Overview** page for your resource group, select **Delete resource group**.
 1. Enter the resource group name to confirm you want to delete it, and select **Delete**.

--- a/Instructions/04-Work-with-environments.md
+++ b/Instructions/04-Work-with-environments.md
@@ -51,7 +51,7 @@ To create the Azure Machine Learning workspace and compute resources, you'll use
 
 When you've created the workspace and necessary compute resources, you can open the Azure Machine Learning studio and clone the lab materials. 
 
-1. In the Azure portal, navigate to the Azure Machine Learning workspace named **mlw-dp100-labs**.
+1. In the Azure portal, navigate to the Azure Machine Learning workspace named **mlw-dp100-xxxx******.
 1. Select the Azure Machine Learning workspace, and in its **Overview** page, select **Launch studio**. Another tab will open in your browser to open the Azure Machine Learning studio.
 1. Close any pop-ups that appear in the studio.
 1. Within the Azure Machine Learning studio, navigate to the **Compute** page and verify that the compute instance and cluster you created in the previous section exist. The compute instance should be running, the cluster should be idle and have 0 nodes running.
@@ -69,19 +69,19 @@ When you've created the workspace and necessary compute resources, you can open 
 
     ```
     git clone https://github.com/MicrosoftLearning/mslearn-azure-ml.git azure-ml-labs
-    ``` 
+    ```
 
-1. When the command has completed, in the **Files** pane, click **&#8635;** to refresh the view and verify that a new **Users/*your-user-name*/azure-ml-labs** folder has been created. 
+1. When the command has completed, in the **Files** pane, click **&#8635;** to refresh the view and verify that a new **Users/*your-user-name*/azure-ml-labs** folder has been created.
 
 ## Work with environments
 
-The code to create and manage environments with the Python SDK is provided in a notebook. 
+The code to create and manage environments with the Python SDK is provided in a notebook.
 
 1. Open the **Labs/04/Work with environments.ipynb** notebook.
 
-    > Select **Authenticate** and follow the necessary steps if a notification appears asking you to authenticate. 
+    > Select **Authenticate** and follow the necessary steps if a notification appears asking you to authenticate.
 
-1. Verify that the notebook uses the **Python 3.8 - AzureML** kernel. 
+1. Verify that the notebook uses the **Python 3.8 - AzureML** kernel.
 1. Run all cells in the notebook.
 
 ## Delete Azure resources
@@ -91,6 +91,5 @@ When you finish exploring Azure Machine Learning, you should delete the resource
 1. Close the Azure Machine Learning studio tab and return to the Azure portal.
 1. In the Azure portal, on the **Home** page, select **Resource groups**.
 1. Select the **rg-dp100-labs** resource group.
-1. At the top of the **Overview** page for your resource group, select **Delete resource group**. 
+1. At the top of the **Overview** page for your resource group, select **Delete resource group**.
 1. Enter the resource group name to confirm you want to delete it, and select **Delete**.
-

--- a/Instructions/05-Designer-train-model.md
+++ b/Instructions/05-Designer-train-model.md
@@ -109,6 +109,6 @@ When you finish exploring Azure Machine Learning, you should delete the resource
 
 1. Close the Azure Machine Learning studio tab and return to the Azure portal.
 1. In the Azure portal, on the **Home** page, select **Resource groups**.
-1. Select the **rg-dp100-...** resource group.
+1. Select the **rg-dp100-xxxx** resource group.
 1. At the top of the **Overview** page for your resource group, select **Delete resource group**.
 1. Enter the resource group name to confirm you want to delete it, and select **Delete**.

--- a/Instructions/05-Designer-train-model.md
+++ b/Instructions/05-Designer-train-model.md
@@ -51,7 +51,7 @@ To create the Azure Machine Learning workspace and a compute cluster, you'll use
 
 When you've created the workspace and necessary compute cluster, you can open the Azure Machine Learning studio and create a training pipeline with the Designer.
 
-1. In the Azure portal, navigate to the Azure Machine Learning workspace named **mlw-dp100-xxxx**.
+1. In the Azure portal, navigate to the Azure Machine Learning workspace named **mlw-dp100-...**.
 1. Select the Azure Machine Learning workspace, and in its **Overview** page, select **Launch studio**. Another tab will open in your browser to open the Azure Machine Learning studio.
 1. Close any pop-ups that appear in the studio.
 1. Within the Azure Machine Learning studio, navigate to the **Compute** page and verify that the compute cluster you created in the previous section exist. The cluster should be idle and have 0 nodes running.
@@ -109,6 +109,6 @@ When you finish exploring Azure Machine Learning, you should delete the resource
 
 1. Close the Azure Machine Learning studio tab and return to the Azure portal.
 1. In the Azure portal, on the **Home** page, select **Resource groups**.
-1. Select the **rg-dp100-xxxx** resource group.
+1. Select the **rg-dp100-...** resource group.
 1. At the top of the **Overview** page for your resource group, select **Delete resource group**.
 1. Enter the resource group name to confirm you want to delete it, and select **Delete**.

--- a/Instructions/05-Designer-train-model.md
+++ b/Instructions/05-Designer-train-model.md
@@ -109,6 +109,6 @@ When you finish exploring Azure Machine Learning, you should delete the resource
 
 1. Close the Azure Machine Learning studio tab and return to the Azure portal.
 1. In the Azure portal, on the **Home** page, select **Resource groups**.
-1. Select the **rg-dp100-labs** resource group.
+1. Select the **rg-dp100-xxxx** resource group.
 1. At the top of the **Overview** page for your resource group, select **Delete resource group**.
 1. Enter the resource group name to confirm you want to delete it, and select **Delete**.

--- a/Instructions/05-Designer-train-model.md
+++ b/Instructions/05-Designer-train-model.md
@@ -58,7 +58,7 @@ When you've created the workspace and necessary compute cluster, you can open th
 1. Navigate to the **Designer** page.
 1. Select the **Custom** tab at the top of the page.
 1. Create a new empty pipeline using custom components.
-1. Change the default pipeline name (**Pipeline-Created-on-*date***) to `Train-Diabetes-Classifier` by selecting the pencil icon on its righ.
+1. Change the default pipeline name (**Pipeline-Created-on-*date***) to `Train-Diabetes-Classifier` by selecting the pencil icon on its right.
 
 
 ## Create a new pipeline
@@ -109,6 +109,6 @@ When you finish exploring Azure Machine Learning, you should delete the resource
 
 1. Close the Azure Machine Learning studio tab and return to the Azure portal.
 1. In the Azure portal, on the **Home** page, select **Resource groups**.
-1. Select the **rg-dp100-xxxx** resource group.
+1. Select the **rg-dp100-...** resource group.
 1. At the top of the **Overview** page for your resource group, select **Delete resource group**.
 1. Enter the resource group name to confirm you want to delete it, and select **Delete**.

--- a/Instructions/05-Designer-train-model.md
+++ b/Instructions/05-Designer-train-model.md
@@ -15,7 +15,7 @@ You'll need an [Azure subscription](https://azure.microsoft.com/free?azure-porta
 
 ## Provision an Azure Machine Learning workspace
 
-An Azure Machine Learning *workspace* provides a central place for managing all resources and assets you need to train and manage your models. You can interact with the Azure Machine Learning workspace through the studio, Python SDK, and Azure CLI. 
+An Azure Machine Learning *workspace* provides a central place for managing all resources and assets you need to train and manage your models. You can interact with the Azure Machine Learning workspace through the studio, Python SDK, and Azure CLI.
 
 You'll use a Shell script which uses the Azure CLI to provision the workspace and necessary resources. Next, you'll use the Designer in the Azure Machine Learning studio to train and compare models.
 
@@ -25,7 +25,7 @@ To create the Azure Machine Learning workspace and a compute cluster, you'll use
 
 1. In a browser, open the Azure portal at `https://portal.azure.com/`, signing in with your Microsoft account.
 1. Select the \[>_] (*Cloud Shell*) button at the top of the page to the right of the search box. This opens a Cloud Shell pane at the bottom of the portal.
-1. Select **Bash** if asked. The first time you open the cloud shell, you will be asked to choose the type of shell you want to use (*Bash* or *PowerShell*). 
+1. Select **Bash** if asked. The first time you open the cloud shell, you will be asked to choose the type of shell you want to use (*Bash* or *PowerShell*).
 1. Check that the correct subscription is specified and select **Create storage** if you are asked to create storage for your cloud shell. Wait for the storage to be created.
 1. In the terminal, enter the following commands to clone this repo:
 
@@ -34,7 +34,7 @@ To create the Azure Machine Learning workspace and a compute cluster, you'll use
     git clone https://github.com/MicrosoftLearning/mslearn-azure-ml.git azure-ml-labs
     ```
 
-    > Use `SHIFT + INSERT` to paste your copied code into the Cloud Shell. 
+    > Use `SHIFT + INSERT` to paste your copied code into the Cloud Shell.
 
 1. After the repo has been cloned, enter the following commands to change to the folder for this lab and run the setup.sh script it contains:
 
@@ -43,25 +43,26 @@ To create the Azure Machine Learning workspace and a compute cluster, you'll use
     ./setup.sh
     ```
 
-    > Ignore any (error) messages that say that the extensions were not installed. 
+    > Ignore any (error) messages that say that the extensions were not installed.
 
-1. Wait for the script to complete - this typically takes around 5-10 minutes. 
+1. Wait for the script to complete - this typically takes around 5-10 minutes.
 
 ## Configure a new pipeline
 
-When you've created the workspace and necessary compute cluster, you can open the Azure Machine Learning studio and create a training pipeline with the Designer. 
+When you've created the workspace and necessary compute cluster, you can open the Azure Machine Learning studio and create a training pipeline with the Designer.
 
-1. In the Azure portal, navigate to the Azure Machine Learning workspace named **mlw-dp100-labs**.
+1. In the Azure portal, navigate to the Azure Machine Learning workspace named **mlw-dp100-xxxx**.
 1. Select the Azure Machine Learning workspace, and in its **Overview** page, select **Launch studio**. Another tab will open in your browser to open the Azure Machine Learning studio.
 1. Close any pop-ups that appear in the studio.
 1. Within the Azure Machine Learning studio, navigate to the **Compute** page and verify that the compute cluster you created in the previous section exist. The cluster should be idle and have 0 nodes running.
 1. Navigate to the **Designer** page.
 1. Select the **Custom** tab at the top of the page.
 1. Create a new empty pipeline using custom components.
-1. Change the default pipeline name (**Pipeline-Created-on-*date***) to `Train-Diabetes-Classifier` by clicking the **&#9881;** icon at the right to open the **Settings** pane.
-1. You'll need to specify a compute target on which to run the pipeline. In the **Settings** pane, under **Select compute type** and select **Compute cluster**, and under **Select Azure ML compute cluster** and select **aml-cluster**. Close the settings pane.
+1. Change the default pipeline name (**Pipeline-Created-on-*date***) to `Train-Diabetes-Classifier` by selecting the pencil icon on its righ.
+
 
 ## Create a new pipeline
+
 To train a model, you'll need data. You can use any data stored in a datastore or use a publicly accessible URL.
 
 1. In the left menu, select the **Data** tab.
@@ -70,32 +71,36 @@ To train a model, you'll need data. You can use any data stored in a datastore o
     Now that you have your data, you can continue by creating a pipeline using custom components that already exist within the workspace (were created for you during setup).
 
 1. In the left menu, select the **Components** tab.
-1. Drag and drop the **Remove Empty Rows** component on to the canvas, below the **diabetes-folder**. 
+1. Drag and drop the **Remove Empty Rows** component on to the canvas, below the **diabetes-folder**.
 1. Connect the output of the data to the input of the new component.
-1. Drag and drop the **Normalize Numerical Columns** component on to the canvas, below the **Remove Empty Rows**. 
+1. Drag and drop the **Normalize Numerical Columns** component on to the canvas, below the **Remove Empty Rows**.
 1. Connect the output of the previous component to the input of the new component.
 1. Drag and drop the **Train a Decision Tree Classifier Model** component on to the canvas, below the **Normalize Numerical Columns**.
-1. Connect the output of the previous component to the input of the new component. 
-1. Submit your pipeline. 
-1. Create a new experiment and name it `diabetes-designer-pipeline`. 
+1. Connect the output of the previous component to the input of the new component.
+1. Select **Configure & Submit** and in the **Set up pipeline job** page create a new experiment and name it `diabetes-designer-pipeline`, then select **Next**.
+1. On the **Inputs & Outputs** make no changes and select **Next**.
+1. On the **Runtime settings** select **Compute Cluster**, and under the **Select Azure ML compute cluster** select your *aml-cluster*.
+1. Select **Review + Submit** and then select **Submit** to start the pipeline run.
+1. You can check the status of the run by going to the **Pipelines** page and selecting the **Train-Diabetes-Classifier** pipeline.
 1. Wait until all components have successfully completed.
 
-    Submitting the job will initialize the compute cluster. As the compute cluster was idle up until now, it may take some time for the cluster to resize to more than 0 nodes. Once the cluster has resized, it will automatically start running the pipeline. 
+    Submitting the job will initialize the compute cluster. As the compute cluster was idle up until now, it may take some time for the cluster to resize to more than 0 nodes. Once the cluster has resized, it will automatically start running the pipeline.
 
-1. You can view the status of the pipeline run by selecting **Job detail** in the **Submitted jobs** pane on the left.
-
-You'll be able to track the run of each component. When the pipeline fails, you'll be able to explore which component failed and why it failed. Error messages will show in the **Outputs + logs** tab of the job overview. 
+You'll be able to track the run of each component. When the pipeline fails, you'll be able to explore which component failed and why it failed. Error messages will show in the **Outputs + logs** tab of the job overview.
 
 ## Train a second model to compare
 
 To compare between algorithms and evaluate which performs better, you can train two models within one pipeline and compare.
 
-1. Within the same pipeline you've been working in so far
+1. Return to the **Designer** and select the **Train-Diabetes-Classifier** pipeline draft.
 1. Add the **Train a Logistic Regression Classifier Model** component to the canvas, next to the other training component.
-1. Connect the output of the **Normalize Numerical Columns** component to the input of the new training component. 
-1. At the top, select **Submit**. 
-1. When prompted, create a new experiment named `designer-compare-classification`, and run it.  
-1. When the pipeline has completed, review the **Metrics** for both training components.
+1. Connect the output of the **Normalize Numerical Columns** component to the input of the new training component.
+1. At the top, select **Configure & Submit**.
+1. On the **Basics** page, create a new experiment named `designer-compare-classification`, and run it.
+1. Select **Review + Submit** and then select **Submit** to start the pipeline run.
+1. You can check the status of the run by going to the **Pipelines** page and selecting the **Train-Diabetes-Classifier** pipeline with the **designer-compare-classification** experiment.
+1. Wait until all components have successfully completed.  
+1. Select **Job overview**, then select the **Metrics** tab to review the results for both training components.
 1. Try and determine which model performed better.
 
 ## Delete Azure resources
@@ -105,5 +110,5 @@ When you finish exploring Azure Machine Learning, you should delete the resource
 1. Close the Azure Machine Learning studio tab and return to the Azure portal.
 1. In the Azure portal, on the **Home** page, select **Resource groups**.
 1. Select the **rg-dp100-labs** resource group.
-1. At the top of the **Overview** page for your resource group, select **Delete resource group**. 
+1. At the top of the **Overview** page for your resource group, select **Delete resource group**.
 1. Enter the resource group name to confirm you want to delete it, and select **Delete**.


### PR DESCRIPTION
Small changes to labs 2 and 4. Bigger changes to lab 5(UI chanbges in the pipeline designer)

Changes proposed in this pull request:

Lab 2 : fix "workstation" and removed some trailing spaces
Lab 4: fixed workspace name and removed some trailing spaces
Lab5 : 

- fixed workspace name
- changed instructions for renaming pipeline
- changed instructions for running a pipeline
- added instructions on how to view pipeline draft result
- removed some trailing spaces
