### PR TITLE
Sync metric names in lab 9

### DIFF
--- a/Labs/09/Hyperparameter tuning.ipynb
+++ b/Labs/09/Hyperparameter tuning.ipynb
@@ -190,7 +190,7 @@
         "    y_hat = model.predict(X_test)\n",
         "    acc = np.average(y_hat == y_test)\n",
         "    print('Accuracy:', acc)\n",
-        "    mlflow.log_metric(\"Accuracy\", acc)\n",
+        "    mlflow.log_metric(\"training_accuracy_score\", acc)\n",
         "\n",
         "    # calculate AUC\n",
         "    y_scores = model.predict_proba(X_test)\n",


### PR DESCRIPTION
The hyperparameter sweep is defined on the "training_accuracy_score" but in the training script no metric is logged under this name. Nothing will break as the sweep seems to default to "Accuracy", but the jobs will show N/A for training_accuracy_score. The corresponding plot will not show training_accuracy_score at all, but instead use the default Accuracy.

I'd prefer logging the metric as "training_accuracy_score" because this makes it more clear you can customize the metric name you want to optimize over.

# Module: 00
## Lab/Demo: 9

Changes proposed in this pull request:

- Fix wrong metric name
