### PR TITLE
Update setup.sh resolve "Bad substitution"

### DIFF
--- a/Labs/03/setup.sh
+++ b/Labs/03/setup.sh
@@ -1,4 +1,4 @@
-#! /usr/bin/sh
+#! /usr/bin/bash
 
 # Create random string
 guid=$(cat /proc/sys/kernel/random/uuid)


### PR DESCRIPTION
Using the shell replace commands in line 5 and 6 requires bash as sh does not support it AFAIK.  If accepted, this change should be applied to all the "setup.sh".

Without this change you will get a "Bad substitution" error:

./setup.sh: 5: Bad substitution

uname -a
Linux kevinsay2 5.15.0-1040-azure #47~20.04.1-Ubuntu SMP Fri Jun 2 21:38:08 UTC 2023 x86_64 x86_64 x86_64 GNU/Linux

(azureml_py38) azureuser@kevinsay2:~/cloudfiles/code/Users/kevinsay/azure-ml-labs/Labs/03$ echo $0 /bin/bash

# Module: 00
## Lab/Demo: 00

Fixes # .

Changes proposed in this pull request:

-
-
-