### PR TITLE
fix: Fix typo in a markdown section

### DIFF
--- a/Labs/04/Work with compute.ipynb
+++ b/Labs/04/Work with compute.ipynb
@@ -19,7 +19,7 @@
         "\n",
         "## Before you start\n",
         "\n",
-        "You'll need the latest version of the  **azureml-ai-ml** package to run the code in this notebook. Run the cell below to verify that it is installed.\n",
+        "You'll need the latest version of the  **azure-ai-ml** package to run the code in this notebook. Run the cell below to verify that it is installed.\n",
         "\n",
         "> **Note**:\n",
         "> If the **azure-ai-ml** package is not installed, run `pip install azure-ai-ml` to install it."


### PR DESCRIPTION
Change `azureml-ai-ml` to the actual package's reference `azure-ai-ml`

# Module: 04
## Lab/Demo: 04

Fixes # 1

Changes proposed in this pull request:
Change `azureml-ai-ml` to the actual package's reference `azure-ai-ml`