### PR TITLE
fix: Assign `max_instances`=1 according to the comments in a markdown…

### DIFF
--- a/Labs/04/Work with compute.ipynb
+++ b/Labs/04/Work with compute.ipynb
@@ -172,7 +172,7 @@
         "        # Minimum running nodes when there is no job running\n",
         "        min_instances=0,\n",
         "        # Nodes in cluster\n",
-        "        max_instances=2,\n",
+        "        max_instances=1,\n",
         "        # How many seconds will the node running after the job termination\n",
         "        idle_time_before_scale_down=120,\n",
         "        # Dedicated or LowPriority. The latter is cheaper but there is a chance of job termination\n",


### PR DESCRIPTION
… section

Assign `max_instances`=1 to match the comment in the markdown section: 'Currently, your compute cluster `aml-cluster` can only scale do a maximum of one node.'

# Module: 04
## Lab/Demo: 04

Fixes # 1

Changes proposed in this pull request:
Assign `max_instances`=1 (currently `max_instances`=2) to match the comment in the markdown section: 'Currently, your compute cluster `aml-cluster` can only scale do a maximum of one node.'