### PR TITLE
doc: Rephrase a sentence in the markdown section

### DIFF
--- a/Labs/04/Work with compute.ipynb
+++ b/Labs/04/Work with compute.ipynb
@@ -284,7 +284,7 @@
       "source": [
         "## Create a script to train a model\n",
         "\n",
-        "To train a model, you'll first create the **diabetes_training.py** script in the **src** folder. The script uses the **diabetes.csv** file in the same folder as the training data."
+        "To train a model, you'll first create the **diabetes_training.py** script in the **src** folder. The script uses the **diabetes.csv** file as the training data from the same **src** folder."
       ]
     },
     {


### PR DESCRIPTION
Rephrase the sentence to add clarity to 'The script uses the diabetes.csv file in the same folder as the training data.'

# Module: 04
## Lab/Demo: 04

Fixes # .

Changes proposed in this pull request:
Rephrase the sentence 'The script uses the diabetes.csv file in the same folder as the training data.' to 'The script uses the diabetes.csv file as the training data from the same src folder.'