### PR TITLE
fix: Remove logging of a parameter while using mlflow.autolog()

### DIFF
--- a/Labs/08/Use MLflow to track jobs.ipynb
+++ b/Labs/08/Use MLflow to track jobs.ipynb
@@ -361,7 +361,6 @@
         "\n",
         "# function that trains the model\n",
         "def train_model(reg_rate, X_train, X_test, y_train, y_test):\n",
-        "    mlflow.log_param(\"Regularization rate\", reg_rate)\n",
         "    print(\"Training model...\")\n",
         "    model = LogisticRegression(C=1/reg_rate, solver=\"liblinear\").fit(X_train, y_train)\n",
         "\n",


### PR DESCRIPTION
mlflow.log_param("Regularization rate", reg_rate) was removed since mlflow.autolog() is used above and it isn't mentioned to pay attention on the additionally logged `Regularization rate` in the **Detail** section of AML Studio

# Module: 08
## Lab/Demo: 08

Fixes # 1

Changes proposed in this pull request:
Either remove manual logging while using mlflow.autolog() or add a comment, to make people pay attention on the difference between manual and auto logging looking at the **Detail** section of AML Studio