### PR TITLE
fix: Fix typo in markdown section

### DIFF
--- a/Labs/10/Log models with MLflow.ipynb
+++ b/Labs/10/Log models with MLflow.ipynb
@@ -11,7 +11,7 @@
         "\n",
         "## Before you start\n",
         "\n",
-        "You'll need the latest version of the **azureml-ai-ml** package to run the code in this notebook. Run the cell below to verify that it is installed.\n",
+        "You'll need the latest version of the **azure-ai-ml** package to run the code in this notebook. Run the cell below to verify that it is installed.\n",
         "\n",
         "> **Note**:\n",
         "> If the **azure-ai-ml** package is not installed, run `pip install azure-ai-ml` to install it."


### PR DESCRIPTION
The package name `azureml-ai-ml` is changed to `azure-ai-ml`

# Module: 10
## Lab/Demo: 10

Fixes # 1

Changes proposed in this pull request:
The package name `azureml-ai-ml` is changed to `azure-ai-ml`