### PR TITLE
fix: Remove logging of a parameter while using mlflow.sklearn.autolog()

### DIFF
--- a/Labs/10/Log models with MLflow.ipynb
+++ b/Labs/10/Log models with MLflow.ipynb
@@ -328,7 +328,6 @@
         "\n",
         "# function that trains the model\n",
         "def train_model(reg_rate, X_train, X_test, y_train, y_test):\n",
-        "    mlflow.log_param(\"Regularization rate\", reg_rate)\n",
         "    print(\"Training model...\")\n",
         "    model = LogisticRegression(C=1/reg_rate, solver=\"liblinear\").fit(X_train, y_train)\n",
         "\n",


### PR DESCRIPTION
mlflow.log_param("Regularization rate", reg_rate) was removed since mlflow.sklearn.autolog() is used above and it isn't mentioned to pay attention on the additionally logged Regularization rate in the Detail section of AML Studio

# Module: 10
## Lab/Demo: 10

Fixes # 1

Changes proposed in this pull request:
Either remove manual logging while using mlflow.sklearn.autolog() or add a comment, to make people pay attention on the difference between manual and auto logging looking at the Detail section of AML Studio