### PR TITLE
refactor: Change an instance type to an available for free trial

### DIFF
--- a/Labs/11/Deploy to online endpoint.ipynb
+++ b/Labs/11/Deploy to online endpoint.ipynb
@@ -232,7 +232,7 @@
         "    name=\"blue\",\n",
         "    endpoint_name=online_endpoint_name,\n",
         "    model=model,\n",
-        "    instance_type=\"Standard_F4s_v2\",\n",
+        "    instance_type=\"Standard_D2a_v4\",\n",
         "    instance_count=1,\n",
         ")"
       ]


### PR DESCRIPTION
Change an `instance_type` Standard_F4s_v2 to Standard_D2a_v4 in `Deploy to online endpoint.ipynb` to make `ManagedOnlineDeployment` available for free trial.

# Module: 11
## Lab/Demo: 11

Fixes # 1

Changes proposed in this pull request:
Change an `instance_type` Standard_F4s_v2 to Standard_D2a_v4 in `Deploy to online endpoint.ipynb` to make `ManagedOnlineDeployment` available for free trial.