### PR TITLE
Updated max_instances

### DIFF
--- a/Labs/04/Work with compute.ipynb
+++ b/Labs/04/Work with compute.ipynb
@@ -172,7 +172,7 @@
         "        # Minimum running nodes when there is no job running\n",
         "        min_instances=0,\n",
         "        # Nodes in cluster\n",
-        "        max_instances=2,\n",
+        "        max_instances=1,\n",
         "        # How many seconds will the node running after the job termination\n",
         "        idle_time_before_scale_down=120,\n",
         "        # Dedicated or LowPriority. The latter is cheaper but there is a chance of job termination\n",


### PR DESCRIPTION
The max_instances is set to 2, and then increased to 2 in the next cell. It should be set to 1 and then increased to 2.

# Module: 00
## Lab/Demo: 00

Fixes # .

Changes proposed in this pull request:

- The max_instances is set to 2, and then increased to 2 in the next cell. It should be set to 1 and then increased to 2.