### PR TITLE
docs(notebooks-mlflow-tracking): work around upgrade for `typing-extensions` import error

### DIFF
--- a/Labs/07/Track model training with MLflow.ipynb
+++ b/Labs/07/Track model training with MLflow.ipynb
@@ -54,6 +54,14 @@
       ]
     },
     {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "> **Note**:\n",
+        "> If unable to run cell(s) due to `ImportError: cannot import name 'ParamSpec' from 'typing_extensions' ...`, run `pip install typing-extensions==4.3.0` to resolve the error."
+      ]
+    },
+    {
       "cell_type": "code",
       "execution_count": null,
       "metadata": {


### PR DESCRIPTION
# Module: Track model training in Jupyter notebooks with MLflow 
## Lab/Demo: 07

provide note for install suitable `typing-extension` to resolve import error

Fixes #91 

```
# File /anaconda/envs/azureml_py38/lib/python3.8/site-packages/azure/core/tracing/decorator.py:31
#      28 import functools
#      30 from typing import Callable, Any, TypeVar, overload, Optional
# ---> 31 from typing_extensions import ParamSpec
#      32 from .common import change_context, get_function_and_class_name
#      33 from . import SpanKind as _SpanKind

# ImportError: cannot import name 'ParamSpec' from 'typing_extensions' (/anaconda/envs/azureml_py38/lib/python3.8/site-packages/typing_extensions.py)
```

Changes proposed in this pull request:

- Add note in Jupyter notebook, to install newer version of `typing-extension`.