### PR TITLE
"can only scale do.." --> "can only scale to.."

### DIFF
--- a/Labs/04/Work with compute.ipynb
+++ b/Labs/04/Work with compute.ipynb
@@ -187,7 +187,7 @@
         "- `max_instances`: Maximum number of nodes\n",
         "- `idle_time_before_scale_down`: Idle time before scale down\n",
         "\n",
-        "Currently, your compute cluster `aml-cluster` can only scale do a maximum of one node. Let's change that to two, to allow for parallel compute."
+        "Currently, your compute cluster `aml-cluster` can only scale to a maximum of one node. Let's change that to two, to allow for parallel compute."
       ]
     },
     {


### PR DESCRIPTION
Corrected typo in markdown cell comment. 
"Currently, your compute cluster `aml-cluster` can only scale do a maximum..." -->  "Currently, your compute cluster `aml-cluster` can only scale to a maximum..."

# Module: 00
## Lab/Demo: 00

Fixes # .

Changes proposed in this pull request:

-
-
-