### PR TITLE
Adding new setup1.sh file

### DIFF
--- a/Labs/05/setup1.sh
+++ b/Labs/05/setup1.sh
@@ -1,0 +1,49 @@
+#! /usr/bin/sh
+
+# Check if a suffix was passed as an argument
+if [[ -n "$1" ]]; then
+  suffix=$1
+else
+  # Generate random suffix from UUID if none was provided
+  guid=$(cat /proc/sys/kernel/random/uuid)
+  suffix=${guid//[-]/}
+  suffix=${suffix:0:18}
+fi
+
+echo "Suffix: $suffix"
+
+# Set the necessary variables
+RESOURCE_GROUP="rg-dp100-l${suffix}"
+RESOURCE_PROVIDER="Microsoft.MachineLearningServices"
+REGIONS=("eastus" "westus" "centralus" "northeurope" "westeurope")
+RANDOM_REGION=${REGIONS[$RANDOM % ${#REGIONS[@]}]}
+WORKSPACE_NAME="mlw-dp100-l${suffix}"
+COMPUTE_CLUSTER="aml-cluster"
+
+# Register the Azure Machine Learning resource provider in the subscription
+echo "Register the Machine Learning resource provider:"
+az provider register --namespace $RESOURCE_PROVIDER
+
+# Create the resource group and workspace and set to default
+echo "Create a resource group and set as default:"
+az group create --name $RESOURCE_GROUP --location $RANDOM_REGION
+az configure --defaults group=$RESOURCE_GROUP
+
+echo "Create an Azure Machine Learning workspace:"
+az ml workspace create --name $WORKSPACE_NAME 
+az configure --defaults workspace=$WORKSPACE_NAME 
+
+# Create compute cluster
+echo "Creating a compute cluster with name: " $COMPUTE_CLUSTER
+az ml compute create --name ${COMPUTE_CLUSTER} --size STANDARD_DS11_V2 --max-instances 2 --type AmlCompute 
+
+# Create data asset
+echo "Creating a data asset with name: diabetes-folder"
+az ml data create --name diabetes-folder --path ./data 
+
+# Create components
+echo "Creating components"
+az ml component create --file ./fix-missing-data.yml 
+az ml component create --file ./normalize-data.yml 
+az ml component create --file ./train-decision-tree.yml 
+az ml component create --file ./train-logistic-regression.yml 

--- a/Labs/06/setup1.sh
+++ b/Labs/06/setup1.sh
@@ -1,0 +1,47 @@
+#! /usr/bin/sh
+
+# Check if a suffix was passed as an argument
+if [[ -n "$1" ]]; then
+  suffix=$1
+else
+  # Generate random suffix from UUID if none was provided
+  guid=$(cat /proc/sys/kernel/random/uuid)
+  suffix=${guid//[-]/}
+  suffix=${suffix:0:18}
+fi
+
+echo "Suffix: $suffix"
+# Set the necessary variables
+RESOURCE_GROUP="rg-dp100-l${suffix}"
+RESOURCE_PROVIDER="Microsoft.MachineLearningServices"
+REGIONS=("eastus" "westus" "centralus" "northeurope" "westeurope")
+RANDOM_REGION=${REGIONS[$RANDOM % ${#REGIONS[@]}]}
+WORKSPACE_NAME="mlw-dp100-l${suffix}"
+COMPUTE_INSTANCE="ci${suffix}"
+COMPUTE_CLUSTER="aml-cluster"
+
+# Register the Azure Machine Learning resource provider in the subscription
+echo "Register the Machine Learning resource provider:"
+az provider register --namespace $RESOURCE_PROVIDER
+
+# Create the resource group and workspace and set to default
+echo "Create a resource group and set as default:"
+az group create --name $RESOURCE_GROUP --location $RANDOM_REGION
+az configure --defaults group=$RESOURCE_GROUP
+
+echo "Create an Azure Machine Learning workspace:"
+az ml workspace create --name $WORKSPACE_NAME 
+az configure --defaults workspace=$WORKSPACE_NAME 
+
+# Create compute instance
+echo "Creating a compute instance with name: " $COMPUTE_INSTANCE
+az ml compute create --name ${COMPUTE_INSTANCE} --size STANDARD_DS11_V2 --type ComputeInstance 
+
+# Create compute cluster
+echo "Creating a compute cluster with name: " $COMPUTE_CLUSTER
+az ml compute create --name ${COMPUTE_CLUSTER} --size STANDARD_DS11_V2 --max-instances 2 --type AmlCompute 
+
+# Create data assets
+echo "Create training data asset:"
+az ml data create --type mltable --name "diabetes-training" --path ./diabetes-data 
+az ml data create --type mltable --name "oj-training" --path ./orange-juice-data 

--- a/Labs/07/setup1.sh
+++ b/Labs/07/setup1.sh
@@ -1,0 +1,38 @@
+#! /usr/bin/sh
+
+# Check if a suffix was passed as an argument
+if [[ -n "$1" ]]; then
+  suffix=$1
+else
+  # Generate random suffix from UUID if none was provided
+  guid=$(cat /proc/sys/kernel/random/uuid)
+  suffix=${guid//[-]/}
+  suffix=${suffix:0:18}
+fi
+
+echo "Suffix: $suffix"
+
+# Set the necessary variables
+RESOURCE_GROUP="rg-dp100-l${suffix}"
+RESOURCE_PROVIDER="Microsoft.MachineLearningServices"
+REGIONS=("eastus" "westus" "centralus" "northeurope" "westeurope")
+RANDOM_REGION=${REGIONS[$RANDOM % ${#REGIONS[@]}]}
+WORKSPACE_NAME="mlw-dp100-l${suffix}"
+COMPUTE_INSTANCE="ci${suffix}"
+
+# Register the Azure Machine Learning resource provider in the subscription
+echo "Register the Machine Learning resource provider:"
+az provider register --namespace $RESOURCE_PROVIDER
+
+# Create the resource group and workspace and set to default
+echo "Create a resource group and set as default:"
+az group create --name $RESOURCE_GROUP --location $RANDOM_REGION
+az configure --defaults group=$RESOURCE_GROUP
+
+echo "Create an Azure Machine Learning workspace:"
+az ml workspace create --name $WORKSPACE_NAME 
+az configure --defaults workspace=$WORKSPACE_NAME 
+
+# Create compute instance
+echo "Creating a compute instance with name: " $COMPUTE_INSTANCE
+az ml compute create --name ${COMPUTE_INSTANCE} --size STANDARD_DS11_V2 --type ComputeInstance 

--- a/Labs/08/setup1.sh
+++ b/Labs/08/setup1.sh
@@ -1,0 +1,43 @@
+#! /usr/bin/sh
+
+# Check if a suffix was passed as an argument
+if [[ -n "$1" ]]; then
+  suffix=$1
+else
+  # Generate random suffix from UUID if none was provided
+  guid=$(cat /proc/sys/kernel/random/uuid)
+  suffix=${guid//[-]/}
+  suffix=${suffix:0:18}
+fi
+
+echo "Suffix: $suffix"
+
+# Set the necessary variables
+RESOURCE_GROUP="rg-dp100-l${suffix}"
+RESOURCE_PROVIDER="Microsoft.MachineLearningServices"
+REGIONS=("eastus" "westus" "centralus" "northeurope" "westeurope")
+RANDOM_REGION=${REGIONS[$RANDOM % ${#REGIONS[@]}]}
+WORKSPACE_NAME="mlw-dp100-l${suffix}"
+COMPUTE_INSTANCE="ci${suffix}"
+COMPUTE_CLUSTER="aml-cluster"
+
+# Register the Azure Machine Learning resource provider in the subscription
+echo "Register the Machine Learning resource provider:"
+az provider register --namespace $RESOURCE_PROVIDER
+
+# Create the resource group and workspace and set to default
+echo "Create a resource group and set as default:"
+az group create --name $RESOURCE_GROUP --location $RANDOM_REGION
+az configure --defaults group=$RESOURCE_GROUP
+
+echo "Create an Azure Machine Learning workspace:"
+az ml workspace create --name $WORKSPACE_NAME 
+az configure --defaults workspace=$WORKSPACE_NAME 
+
+# Create compute instance
+echo "Creating a compute instance with name: " $COMPUTE_INSTANCE
+az ml compute create --name ${COMPUTE_INSTANCE} --size STANDARD_DS11_V2 --type ComputeInstance 
+
+# Create compute cluster
+echo "Creating a compute cluster with name: " $COMPUTE_CLUSTER
+az ml compute create --name ${COMPUTE_CLUSTER} --size STANDARD_DS11_V2 --max-instances 2 --type AmlCompute 

--- a/Labs/09/setup1.sh
+++ b/Labs/09/setup1.sh
@@ -1,0 +1,47 @@
+#! /usr/bin/sh
+
+# Check if a suffix was passed as an argument
+if [[ -n "$1" ]]; then
+  suffix=$1
+else
+  # Generate random suffix from UUID if none was provided
+  guid=$(cat /proc/sys/kernel/random/uuid)
+  suffix=${guid//[-]/}
+  suffix=${suffix:0:18}
+fi
+
+echo "Suffix: $suffix"
+
+# Set the necessary variables
+RESOURCE_GROUP="rg-dp100-l${suffix}"
+RESOURCE_PROVIDER="Microsoft.MachineLearningServices"
+REGIONS=("eastus" "westus" "centralus" "northeurope" "westeurope")
+RANDOM_REGION=${REGIONS[$RANDOM % ${#REGIONS[@]}]}
+WORKSPACE_NAME="mlw-dp100-l${suffix}"
+COMPUTE_INSTANCE="ci${suffix}"
+COMPUTE_CLUSTER="aml-cluster"
+
+# Register the Azure Machine Learning resource provider in the subscription
+echo "Register the Machine Learning resource provider:"
+az provider register --namespace $RESOURCE_PROVIDER
+
+# Create the resource group and workspace and set to default
+echo "Create a resource group and set as default:"
+az group create --name $RESOURCE_GROUP --location $RANDOM_REGION
+az configure --defaults group=$RESOURCE_GROUP
+
+echo "Create an Azure Machine Learning workspace:"
+az ml workspace create --name $WORKSPACE_NAME 
+az configure --defaults workspace=$WORKSPACE_NAME 
+
+# Create compute instance
+echo "Creating a compute instance with name: " $COMPUTE_INSTANCE
+az ml compute create --name ${COMPUTE_INSTANCE} --size STANDARD_DS11_V2 --type ComputeInstance 
+
+# Create compute cluster
+echo "Creating a compute cluster with name: " $COMPUTE_CLUSTER
+az ml compute create --name ${COMPUTE_CLUSTER} --size STANDARD_DS11_V2 --max-instances 2 --type AmlCompute 
+
+# Create data assets
+echo "Create training data asset:"
+az ml data create --type uri_file --name "diabetes-data" --path ./data/diabetes.csv 

--- a/Labs/10/setup1.sh
+++ b/Labs/10/setup1.sh
@@ -1,0 +1,43 @@
+#! /usr/bin/sh
+
+# Check if a suffix was passed as an argument
+if [[ -n "$1" ]]; then
+  suffix=$1
+else
+  # Generate random suffix from UUID if none was provided
+  guid=$(cat /proc/sys/kernel/random/uuid)
+  suffix=${guid//[-]/}
+  suffix=${suffix:0:18}
+fi
+
+echo "Suffix: $suffix"
+
+# Set the necessary variables
+RESOURCE_GROUP="rg-dp100-l${suffix}"
+RESOURCE_PROVIDER="Microsoft.MachineLearningServices"
+REGIONS=("eastus" "westus" "centralus" "northeurope" "westeurope")
+RANDOM_REGION=${REGIONS[$RANDOM % ${#REGIONS[@]}]}
+WORKSPACE_NAME="mlw-dp100-l${suffix}"
+COMPUTE_INSTANCE="ci${suffix}"
+COMPUTE_CLUSTER="aml-cluster"
+
+# Register the Azure Machine Learning resource provider in the subscription
+echo "Register the Machine Learning resource provider:"
+az provider register --namespace $RESOURCE_PROVIDER
+
+# Create the resource group and workspace and set to default
+echo "Create a resource group and set as default:"
+az group create --name $RESOURCE_GROUP --location $RANDOM_REGION
+az configure --defaults group=$RESOURCE_GROUP
+
+echo "Create an Azure Machine Learning workspace:"
+az ml workspace create --name $WORKSPACE_NAME 
+az configure --defaults workspace=$WORKSPACE_NAME 
+
+# Create compute instance
+echo "Creating a compute instance with name: " $COMPUTE_INSTANCE
+az ml compute create --name ${COMPUTE_INSTANCE} --size STANDARD_DS11_V2 --type ComputeInstance 
+
+# Create compute cluster
+echo "Creating a compute cluster with name: " $COMPUTE_CLUSTER
+az ml compute create --name ${COMPUTE_CLUSTER} --size STANDARD_DS11_V2 --max-instances 2 --type AmlCompute 

--- a/Labs/11/setup1.sh
+++ b/Labs/11/setup1.sh
@@ -1,0 +1,44 @@
+#! /usr/bin/sh
+
+# Check if a suffix was passed as an argument
+if [[ -n "$1" ]]; then
+  suffix=$1
+else
+  # Generate random suffix from UUID if none was provided
+  guid=$(cat /proc/sys/kernel/random/uuid)
+  suffix=${guid//[-]/}
+  suffix=${suffix:0:18}
+fi
+
+echo "Suffix: $suffix"
+
+# Set the necessary variables
+RESOURCE_GROUP="rg-dp100-l${suffix}"
+REGIONS=("eastus" "westus" "centralus" "northeurope" "westeurope")
+RANDOM_REGION=${REGIONS[$RANDOM % ${#REGIONS[@]}]}
+WORKSPACE_NAME="mlw-dp100-l${suffix}"
+COMPUTE_INSTANCE="ci${suffix}"
+COMPUTE_CLUSTER="aml-cluster"
+
+# Register the Azure Machine Learning and additional resource providers in the subscription
+echo "Register the required resource providers:"
+az provider register --namespace "Microsoft.MachineLearningServices"
+az provider register --namespace "Microsoft.PolicyInsights"
+az provider register --namespace "Microsoft.Cdn"
+
+# Create the resource group and workspace and set to default
+echo "Create a resource group and set as default:"
+az group create --name $RESOURCE_GROUP --location $RANDOM_REGION
+az configure --defaults group=$RESOURCE_GROUP
+
+echo "Create an Azure Machine Learning workspace:"
+az ml workspace create --name $WORKSPACE_NAME 
+az configure --defaults workspace=$WORKSPACE_NAME 
+
+# Create compute instance
+echo "Creating a compute instance with name: " $COMPUTE_INSTANCE
+az ml compute create --name ${COMPUTE_INSTANCE} --size STANDARD_DS11_V2 --type ComputeInstance 
+
+# Create compute cluster
+echo "Creating a compute cluster with name: " $COMPUTE_CLUSTER
+az ml compute create --name ${COMPUTE_CLUSTER} --size STANDARD_DS11_V2 --max-instances 2 --type AmlCompute 


### PR DESCRIPTION
# Module: DP-100
## Lab/Demo: 05-11

Fixes issues with creating suitable ACPs when using existing setup.sh that utilizes random numbers for RG/resource suffix.

Changes proposed in this pull request:

Added Setup1.sh scripts to 05-11 labs folder, scripts are updated to take a variable for suffix if offered, use random numbers (as before) if not.  Otherwise they should operate as before.

ALH's that wish to use the functionality, would run the setup1.sh and pass the desired variable to the script.  For example: (where the # '53262598' below is a LabInstanceID) and thus the resulting RG name + resource names will be created with that as a suffix, allowing suitable ACP creation.

./setup.sh 53262598